### PR TITLE
Remove Accounts Bug (Fixed)

### DIFF
--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -98,7 +98,7 @@ namespace LoLAccountChecker.Views
             var numCheckedAcccounts = Checker.Accounts.Count(a => a.State != Account.Result.Unchecked);
 
             // Progress Bar
-            _progressBar.Value = (numCheckedAcccounts * 100f) / Checker.Accounts.Count();
+            _progressBar.Value = Checker.Accounts.Count > 0 ? ((numCheckedAcccounts * 100f) / Checker.Accounts.Count()) : 0;
 
             // Export Button
             _exportButton.IsEnabled = numCheckedAcccounts > 0;


### PR DESCRIPTION
If one removed all accounts, then an error would be received when trying
to update the progressbar on the mainwindow (Cannot divide by zero
(Checker.Accounts.Count() == 0). This is fixed by a simple true/false
statement (If there is still accounts left, divide by number of
accounts. Else, set progressbar value equal to 0).