### PR TITLE
Refresh Account Data (New Feature)

### DIFF
--- a/Data/Account.cs
+++ b/Data/Account.cs
@@ -13,6 +13,7 @@ namespace LoLAccountChecker.Data
         {
             Unchecked,
             Success,
+            Outdated,
             Error
         }
 
@@ -58,6 +59,9 @@ namespace LoLAccountChecker.Data
 
                     case Result.Unchecked:
                         return "Unchecked";
+
+                    case Result.Outdated:
+                        return "Outdated";
 
                     case Result.Error:
                         return ErrorMessage;

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ You can also import and export checked accounts that you want to see later.
 * IP
 * Champions
 * Skins
-* Rune Pages
+* Runes
 * Email Status
-* SoloQ Rank
+* Solo Queue Rank
 * Date of Last Match Played
 
 ### Requirements:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ You can also import and export checked accounts that you want to see later.
 * IP
 * Champions
 * Skins
-* Runes
+* Rune Pages
 * Email Status
-* Solo Queue Rank
+* SoloQ Rank
 * Date of Last Match Played
 
 ### Requirements:

--- a/Resources/Icons.xaml
+++ b/Resources/Icons.xaml
@@ -3522,11 +3522,11 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <Canvas x:Key="appbar_refresh_counterclockwise_up" Width="76" Height="76" Clip="F1 M 0,0L 76,0L 76,76L 0,76L 0,0">
         <Path Width="39" Height="38" Canvas.Left="19" Canvas.Top="19" Stretch="Fill" Fill="{DynamicResource BlackBrush}" Data="F1 M 58,33.5001L 58,27L 49,19L 40,27.5001L 40,33.5001L 46,28.2097L 46,40.5C 46,46.299 41.299,51 35.5,51C 29.701,51 25,46.299 25,40.5C 25,34.8686 29.4332,30.2727 35,30.0117L 35,24.0074C 26.1186,24.2718 19,31.5546 19,40.5C 19,49.6127 26.3873,57 35.5,57C 44.6127,57 52,49.6127 52,40.5L 52,28.125L 58,33.5001 Z "/>
     </Canvas>
-
+    -->
     <Canvas x:Key="appbar_refresh" Width="76" Height="76" Clip="F1 M 0,0L 76,0L 76,76L 0,76L 0,0">
         <Path Width="34.8333" Height="41.1667" Canvas.Left="20.5833" Canvas.Top="17.4167" Stretch="Fill" Fill="{DynamicResource BlackBrush}" Data="F1 M 38,20.5833C 42.9908,20.5833 47.4912,22.6825 50.6667,26.046L 50.6667,17.4167L 55.4166,22.1667L 55.4167,34.8333L 42.75,34.8333L 38,30.0833L 46.8512,30.0833C 44.6768,27.6539 41.517,26.125 38,26.125C 31.9785,26.125 27.0037,30.6068 26.2296,36.4167L 20.6543,36.4167C 21.4543,27.5397 28.9148,20.5833 38,20.5833 Z M 38,49.875C 44.0215,49.875 48.9963,45.3932 49.7703,39.5833L 55.3457,39.5833C 54.5457,48.4603 47.0852,55.4167 38,55.4167C 33.0092,55.4167 28.5088,53.3175 25.3333,49.954L 25.3333,58.5833L 20.5833,53.8333L 20.5833,41.1667L 33.25,41.1667L 38,45.9167L 29.1487,45.9167C 31.3231,48.3461 34.483,49.875 38,49.875 Z "/>
     </Canvas>
-
+    <!--
     <Canvas x:Key="appbar_religion_christianity" Width="76" Height="76" Clip="F1 M 0,0L 76,0L 76,76L 0,76L 0,0">
         <Path Width="28" Height="38" Canvas.Left="24" Canvas.Top="19" Stretch="Fill" Fill="{DynamicResource BlackBrush}" Data="F1 M 35,19L 41,19L 41,30L 52,30L 52,36L 41,36L 41,57L 35,57L 35,36L 24,36L 24,30L 35,30L 35,19 Z "/>
     </Canvas>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -16,6 +16,17 @@
                     <TextBlock Margin="4 0 0 0" VerticalAlignment="Center" Text="donate" />
                 </StackPanel>
             </Button>
+            <Button Click="BtnRefreshClick">
+                <StackPanel Orientation="Horizontal">
+                    <Rectangle Width="20" Height="20"
+                               Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}">
+                        <Rectangle.OpacityMask>
+                            <VisualBrush Stretch="Fill" Visual="{StaticResource appbar_refresh}" />
+                        </Rectangle.OpacityMask>
+                    </Rectangle>
+                    <TextBlock Margin="4 0 0 0" VerticalAlignment="Center" Text="refresh" />
+                </StackPanel>
+            </Button>
         </Controls:WindowCommands>
     </Controls:MetroWindow.RightWindowCommands>
     <Grid>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -58,7 +58,7 @@ namespace LoLAccountChecker.Views
                 return;
             }
 
-            var numCheckedAcccounts = Checker.Accounts.Count(a => a.State != Account.Result.Unchecked);
+            var numCheckedAcccounts = Checker.Accounts.Count(a => a.State != Account.Result.Unchecked && a.State != Account.Result.Outdated);
 
             // Progress Bar
             _progressBar.Value = Checker.Accounts.Any() ? ((numCheckedAcccounts * 100f) / Checker.Accounts.Count()) : 0;
@@ -92,6 +92,35 @@ namespace LoLAccountChecker.Views
             Process.Start("https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=CHEV6LWPMHUMW");
         }
 
+        private async void BtnRefreshClick(object sender, RoutedEventArgs e)
+        {
+            if (Checker.IsChecking)
+            {
+                await this.ShowMessageAsync("Error", "Please wait for the checking process to be completed.");
+                return;
+            }
+
+            if (AccountsWindow.Instance == null)
+            {
+                AccountsWindow.Instance = new AccountsWindow();
+                AccountsWindow.Instance.Closed += (o, a) => { AccountsWindow.Instance = null; };
+            }
+
+            foreach (Account a in _accountsDataGrid.SelectedItems)
+            {
+                a.State = Account.Result.Outdated;
+            }
+
+            AccountsWindow.Instance.RefreshAccounts();
+            UpdateControls();
+
+            _startButton.Content = "Stop";
+            _statusLabel.Content = "Status: Refreshing...";
+
+            var thread = new Thread(Checker.Start);
+            thread.IsBackground = true;
+            thread.Start();
+        }
         #region Import Button
 
         private void BtnImportClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Allows one to select account(s) that have already been checked, and refresh the account(s) data without having to remove and add the account again (or making it unchecked in the AccountsWindow).